### PR TITLE
Fehler in 'Druckansicht-Definition bearbeiten' behoben

### DIFF
--- a/emonitor/modules/printers/content_admin.py
+++ b/emonitor/modules/printers/content_admin.py
@@ -48,7 +48,7 @@ def getAdminContent(self, **params):
         def _templates():  # get all printer templates
             templates = {}
             for root, dirs, files in os.walk("{}/emonitor/modules/".format(current_app.config.get('PROJECT_ROOT'))):
-                mod = root.replace("{}/emonitor/modules/".format(current_app.config.get('PROJECT_ROOT')), '').replace('\\templates', '')
+                mod = root.replace("{}/emonitor/modules/".format(current_app.config.get('PROJECT_ROOT')), '').replace(os.path.sep+'templates', '')
                 for f in files:
                     if f.endswith('.html') and f.startswith('print.'):
                         if mod not in templates:

--- a/emonitor/modules/printers/printerutils.py
+++ b/emonitor/modules/printers/printerutils.py
@@ -64,7 +64,7 @@ class PrintLayout:
 
         :param filename: print.[layout].html
         """
-        self.module = filename.split('/')[0]
+        self.module = filename.split('.')[0]
         self.filename = '.'.join(filename.split('.')[1:])
         self.parameters = []
         env = Environment(loader=PackageLoader('emonitor.modules.{}'.format(self.module), 'templates'))

--- a/emonitor/modules/printers/printerutils.py
+++ b/emonitor/modules/printers/printerutils.py
@@ -64,7 +64,7 @@ class PrintLayout:
 
         :param filename: print.[layout].html
         """
-        self.module = filename.split('.')[0]
+        self.module = filename.split('/')[0]
         self.filename = '.'.join(filename.split('.')[1:])
         self.parameters = []
         env = Environment(loader=PackageLoader('emonitor.modules.{}'.format(self.module), 'templates'))


### PR DESCRIPTION
Beim Erstellen eines neuen Druckers konnten die Drucklayouts nicht geladen werden.